### PR TITLE
fix: add vercel.json for client-side routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes 404 error on /admin and other routes when accessed directly. Configures Vercel to serve index.html for all routes, allowing React Router to handle client-side routing properly.