### PR TITLE
fix: use rewrites instead of routes in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,8 @@
 {
-  "routes": [
+  "rewrites": [
     {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
The 'routes' directive was catching all requests including assets. Using 'rewrites' allows static files to be served normally while only rewriting non-existent paths to index.html for React Router.