### PR TITLE
feat: add internationalization support with English translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.52.1",
+        "i18next": "^25.3.2",
+        "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-i18next": "^15.6.1",
         "react-router-dom": "^7.1.0"
       },
       "devDependencies": {
@@ -289,6 +292,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2558,6 +2570,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz",
+      "integrity": "sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.0.tgz",
+      "integrity": "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3314,6 +3375,32 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+      "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3694,6 +3781,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,12 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.52.1",
+    "i18next": "^25.3.2",
+    "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-i18next": "^15.6.1",
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,9 +1,12 @@
 import React, { useState } from 'react';
 import { Menu, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { navigationConfig } from '../config/ui';
+import LanguageToggle from './LanguageToggle';
 
 function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const { t } = useTranslation();
 
   // Sort navigation items by order
   const navItems = [...navigationConfig.items].sort((a, b) => a.order - b.order);
@@ -57,25 +60,26 @@ function Header() {
                       className="hover:text-orange-500 transition-colors"
                       onClick={(e) => handleSmoothScroll(e, item.href)}
                     >
-                      {item.name}
+                      {t(item.i18nKey || item.name)}
                     </a>
                   </li>
                 ))}
               </ul>
             </nav>
 
-            {/* CTA Button */}
-            {navigationConfig.cta.showInDesktop && (
-              <div className="hidden lg:block">
+            {/* CTA Button & Language Toggle */}
+            <div className="hidden lg:flex items-center gap-4">
+              {navigationConfig.cta.showInDesktop && (
                 <a 
                   href={navigationConfig.cta.href}
                   className="bg-orange-500 hover:bg-orange-600 px-6 py-2 rounded-md font-medium transition-colors"
                   onClick={(e) => handleSmoothScroll(e, navigationConfig.cta.href)}
                 >
-                  {navigationConfig.cta.text}
+                  {t(navigationConfig.cta.i18nKey || navigationConfig.cta.text)}
                 </a>
-              </div>
-            )}
+              )}
+              <LanguageToggle />
+            </div>
 
             {/* Mobile menu button */}
             <button
@@ -111,10 +115,13 @@ function Header() {
                     className="block w-full bg-orange-500 hover:bg-orange-600 px-6 py-3 rounded-md font-medium text-center"
                     onClick={(e) => handleSmoothScroll(e, navigationConfig.cta.href)}
                   >
-                    {navigationConfig.cta.text}
+                    {t(navigationConfig.cta.i18nKey || navigationConfig.cta.text)}
                   </a>
                 </li>
               )}
+              <li className="pt-4">
+                <LanguageToggle />
+              </li>
             </ul>
           </nav>
         </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { ChevronRight } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { heroContent } from '../data/heroContent';
 
 function Hero() {
+  const { t } = useTranslation();
   return (
     <section className="relative h-screen flex items-center justify-center overflow-hidden">
       {/* Background image with gradient overlay */}
@@ -19,25 +21,25 @@ function Hero() {
       <div className="relative z-10 container mx-auto px-4">
         <div className="max-w-3xl">
           <h1 className="text-5xl lg:text-7xl font-bold mb-6">
-            {heroContent.title.line1}
-            <span className="block text-orange-500">{heroContent.title.line2}</span>
+            {t('hero.title.line1')}
+            <span className="block text-orange-500">{t('hero.title.line2')}</span>
           </h1>
           <p className="text-xl lg:text-2xl text-zinc-300 mb-8">
-            {heroContent.subtitle}
+            {t('hero.subtitle')}
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <a 
               href={heroContent.cta.primary.href}
               className="bg-orange-500 hover:bg-orange-600 px-8 py-3 rounded-md font-medium transition-colors inline-flex items-center justify-center"
             >
-              {heroContent.cta.primary.text}
+              {t('hero.registerNextMatch')}
               <ChevronRight className="ml-2 h-4 w-4" />
             </a>
             <a 
               href={heroContent.cta.secondary.href}
               className="border border-zinc-600 hover:bg-zinc-900 px-8 py-3 rounded-md font-medium transition-colors text-center"
             >
-              {heroContent.cta.secondary.text}
+              {t('hero.viewStandings')}
             </a>
           </div>
         </div>

--- a/src/components/LanguageToggle.jsx
+++ b/src/components/LanguageToggle.jsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+
+export default function LanguageToggle() {
+  const { i18n } = useTranslation();
+
+  const toggleLanguage = () => {
+    const newLang = i18n.language === 'is' ? 'en' : 'is';
+    i18n.changeLanguage(newLang);
+  };
+
+  return (
+    <button
+      onClick={toggleLanguage}
+      className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-zinc-300 hover:text-white transition-colors rounded-md hover:bg-zinc-800"
+      aria-label="Toggle language"
+    >
+      <span className={i18n.language === 'is' ? 'text-white' : 'text-zinc-500'}>
+        IS
+      </span>
+      <span className="text-zinc-600">/</span>
+      <span className={i18n.language === 'en' ? 'text-white' : 'text-zinc-500'}>
+        EN
+      </span>
+    </button>
+  );
+}

--- a/src/config/ui.js
+++ b/src/config/ui.js
@@ -6,6 +6,7 @@ export const navigationConfig = {
   items: [
     { 
       name: 'Mótaserían', 
+      i18nKey: 'nav.matches',
       href: '#matches',
       order: 1,
       showInMobile: true,
@@ -13,6 +14,7 @@ export const navigationConfig = {
     },
     { 
       name: 'Úrslit & Stig', 
+      i18nKey: 'nav.standings',
       href: '#standings',
       order: 2,
       showInMobile: true,
@@ -20,6 +22,7 @@ export const navigationConfig = {
     },
     { 
       name: 'Meðlimir', 
+      i18nKey: 'nav.members',
       href: '#members',
       order: 3,
       showInMobile: true,
@@ -27,6 +30,7 @@ export const navigationConfig = {
     },
     { 
       name: 'Um PRS Iceland', 
+      i18nKey: 'nav.about',
       href: '#about',
       order: 4,
       showInMobile: true,
@@ -37,6 +41,7 @@ export const navigationConfig = {
   // CTA button configuration
   cta: {
     text: 'Skrá í mót',
+    i18nKey: 'nav.registerMatch',
     href: '#matches',
     style: 'primary', // primary, secondary, outline
     showInMobile: false,

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,34 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+import is from './locales/is.json';
+import en from './locales/en.json';
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      is: { translation: is },
+      en: { translation: en }
+    },
+    fallbackLng: 'is',
+    debug: false,
+    
+    interpolation: {
+      escapeValue: false // React already escapes values
+    },
+    
+    detection: {
+      order: ['localStorage'],
+      caches: ['localStorage'],
+      lookupLocalStorage: 'i18nextLng',
+      checkWhitelist: true
+    },
+    
+    // Always default to Icelandic unless explicitly set
+    lng: localStorage.getItem('i18nextLng') || 'is'
+  });
+
+export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,311 @@
+{
+  "nav": {
+    "matches": "Match Series",
+    "standings": "Results & Points",
+    "members": "Members",
+    "about": "About PRS Iceland",
+    "registerMatch": "Register for Match"
+  },
+  "hero": {
+    "title": {
+      "line1": "Precision Rifle Series",
+      "line2": "Iceland"
+    },
+    "subtitle": "Competing at the highest level of PRS in Iceland",
+    "registerNextMatch": "Register for next match",
+    "viewStandings": "View standings"
+  },
+  "about": {
+    "title": "About PRS Iceland",
+    "description": "Precision Rifle Series Iceland is the Icelandic version of the international PRS match series. We offer challenging and exciting competitions where shooters face various conditions.",
+    "features": {
+      "competitions": {
+        "title": "PRS Matches",
+        "description": "Competing at distances from 100-1000 meters"
+      },
+      "community": {
+        "title": "Strong Community",
+        "description": "Over 150 active members nationwide"
+      },
+      "recognition": {
+        "title": "International Recognition",
+        "description": "Part of the international PRS community"
+      },
+      "coverage": {
+        "title": "Nationwide Matches",
+        "description": "Competing on ranges across the country"
+      }
+    }
+  },
+  "matches": {
+    "title": "Upcoming Matches",
+    "subtitle": "Register for upcoming competitions",
+    "ctaBox": {
+      "title": "Ready for the challenge?",
+      "description": "Register for the next match and participate in exciting competition"
+    },
+    "status": {
+      "open": "Open",
+      "filling": "Filling up",
+      "full": "Fully booked"
+    },
+    "registerButton": "Register for match"
+  },
+  "standings": {
+    "title": "Standings",
+    "subtitle": "2025 PRS Iceland Match Series",
+    "tableHeaders": {
+      "rank": "Rank",
+      "name": "Competitor",
+      "division": "Division",
+      "points": "Points",
+      "percentage": "%"
+    },
+    "viewAll": "View full standings →"
+  },
+  "stats": {
+    "activeMembers": {
+      "value": "150+",
+      "label": "Active Members",
+      "description": "Registered competitors nationwide"
+    },
+    "matchesPerYear": {
+      "value": "24",
+      "label": "Matches per year",
+      "description": "Diverse matches year-round"
+    },
+    "yearsActive": {
+      "value": "4",
+      "label": "Years active",
+      "description": "Founded in 2021"
+    },
+    "divisions": {
+      "value": "3",
+      "label": "Match divisions",
+      "description": "Open, Production and Tactical"
+    }
+  },
+  "cta": {
+    "title": "Ready to compete?",
+    "description": "Be part of Iceland's premier PRS club",
+    "becomeMember": "Become a member",
+    "learnMore": "Learn more"
+  },
+  "footer": {
+    "description": "Iceland's premier PRS club",
+    "quickLinks": {
+      "title": "Quick Links",
+      "matchRegistration": "Match Registration",
+      "standings": "Standings",
+      "members": "Members",
+      "about": "About the club"
+    },
+    "contact": {
+      "title": "Contact",
+      "email": "prs@prsiceland.is",
+      "address1": "Stekkjarseli 7",
+      "address2": "109 Reykjavík"
+    },
+    "social": {
+      "title": "Follow us",
+      "facebook": "Facebook",
+      "instagram": "Instagram"
+    },
+    "copyright": "© 2025 PRS Iceland. All rights reserved."
+  },
+  "registration": {
+    "modalTitle": "Registration for",
+    "fields": {
+      "name": {
+        "label": "Name",
+        "placeholder": "Full name"
+      },
+      "email": {
+        "label": "Email",
+        "placeholder": "email@example.com"
+      },
+      "phonenumber": {
+        "label": "Phone",
+        "placeholder": "1234567"
+      },
+      "division": {
+        "label": "Division",
+        "placeholder": "Select division",
+        "options": ["Open", "Production", "Tactical"]
+      },
+      "city": {
+        "label": "City/Municipality (optional)",
+        "placeholder": "e.g. Reykjavík"
+      }
+    },
+    "buttons": {
+      "cancel": "Cancel",
+      "submit": "Confirm registration",
+      "submitting": "Registering..."
+    },
+    "errors": {
+      "duplicate": "You are already registered for this match",
+      "emailExists": "Email is already registered for another competitor",
+      "general": "Registration error. Please try again."
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "PRS Iceland Dashboard",
+      "subtitle": "Manage matches and results",
+      "tabs": {
+        "create": "Create",
+        "manage": "Manage",
+        "results": "Results",
+        "edit": "Edit",
+        "createMatch": "Create match",
+        "manageMatches": "Manage matches",
+        "recordResults": "Record results",
+        "manageResults": "Manage results"
+      },
+      "notice": {
+        "title": "Notice",
+        "text": "This dashboard is still in development. Authentication and security features are missing before production use. All data is stored in the Supabase database and automatically updates on the website."
+      }
+    },
+    "matchForm": {
+      "title": "Create new match",
+      "fields": {
+        "name": {
+          "label": "Match name",
+          "placeholder": "e.g. Vopnafjörður Match"
+        },
+        "date": {
+          "label": "Date"
+        },
+        "location": {
+          "label": "Location",
+          "placeholder": "e.g. Vopnafjörður Shooting Range"
+        },
+        "capacity": {
+          "label": "Maximum competitors"
+        }
+      },
+      "buttons": {
+        "submit": "Create match",
+        "submitting": "Saving..."
+      },
+      "messages": {
+        "success": "Match created!",
+        "error": "Error creating match"
+      }
+    },
+    "matchList": {
+      "title": "All matches",
+      "loading": "Loading matches...",
+      "empty": "No matches registered",
+      "status": {
+        "upcoming": "Upcoming",
+        "ongoing": "Ongoing",
+        "completed": "Completed"
+      },
+      "fields": {
+        "maxCapacity": "Max",
+        "location": "Location",
+        "capacity": "Maximum capacity"
+      },
+      "buttons": {
+        "save": "Save",
+        "cancel": "Cancel",
+        "edit": "Edit match",
+        "delete": "Delete match"
+      },
+      "confirmDelete": "Are you sure you want to delete the match \"{{name}}\"? This will also delete all registrations.",
+      "messages": {
+        "updated": "Match updated!",
+        "deleted": "Match deleted!",
+        "loadError": "Error loading matches",
+        "updateError": "Error updating match",
+        "deleteError": "Error deleting match"
+      }
+    },
+    "registrations": {
+      "title": "Manage registrations",
+      "show": "Show",
+      "hide": "Hide",
+      "loading": "Loading registrations...",
+      "empty": "No registrations for this match",
+      "registered": "Registered",
+      "status": {
+        "confirmed": "Confirmed",
+        "waitlist": "Waitlist",
+        "cancelled": "Cancelled"
+      },
+      "buttons": {
+        "save": "Save changes",
+        "cancel": "Cancel",
+        "editStatus": "Edit status",
+        "delete": "Delete registration"
+      },
+      "confirmDelete": "Are you sure you want to delete registration for {{name}}?",
+      "messages": {
+        "statusUpdated": "Status updated!",
+        "deleted": "Registration deleted!",
+        "loadError": "Error loading registrations",
+        "updateError": "Error updating status",
+        "deleteError": "Error deleting registration"
+      }
+    },
+    "results": {
+      "title": "Record match results",
+      "selectMatch": "Select match",
+      "selectMatchOption": "-- Select match --",
+      "maxScore": "Maximum score in match",
+      "manualPoints": "Enter points manually (otherwise calculated by position)",
+      "competitors": "Competitors",
+      "autoCalculated": "Percentage calculated automatically",
+      "fields": {
+        "name": "Name",
+        "division": "Division",
+        "score": "Score",
+        "percentage": "Percentage",
+        "points": "Points",
+        "calculated": "(calculated)",
+        "byPosition": "(by position)",
+        "required": "*"
+      },
+      "explanation": {
+        "title": "Explanations:",
+        "score": "Score: Total competitor score in the match (manual)",
+        "percentage": "Percentage: Automatically calculated = (Score / Max Score) × 100",
+        "pointsManual": "Points: Entered manually",
+        "pointsAuto": "Points: Calculated by position (1st place = 100p, 2nd = 95p, etc.)"
+      },
+      "buttons": {
+        "save": "Save results",
+        "saving": "Saving results..."
+      },
+      "messages": {
+        "success": "Results saved!",
+        "error": "Error saving results"
+      }
+    }
+  },
+  "common": {
+    "loading": "Loading...",
+    "error": "Error",
+    "success": "Operation successful",
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "edit": "Edit",
+    "close": "Close",
+    "confirm": "Confirm",
+    "search": "Search",
+    "filter": "Filter",
+    "all": "All",
+    "none": "None",
+    "yes": "Yes",
+    "no": "No",
+    "auto": "Auto"
+  },
+  "seo": {
+    "defaultTitle": "PRS Iceland - Precision Rifle Series",
+    "description": "Iceland's premier precision rifling club."
+  }
+}

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -1,0 +1,311 @@
+{
+  "nav": {
+    "matches": "Mótaserían",
+    "standings": "Úrslit & Stig",
+    "members": "Meðlimir",
+    "about": "Um PRS Iceland",
+    "registerMatch": "Skrá í mót"
+  },
+  "hero": {
+    "title": {
+      "line1": "Precision Rifle Series",
+      "line2": "Iceland"
+    },
+    "subtitle": "Keppt á hæsta stigi PRS á Íslandi",
+    "registerNextMatch": "Skrá í næsta mót",
+    "viewStandings": "Sjá stigastöðu"
+  },
+  "about": {
+    "title": "Um PRS Iceland",
+    "description": "Precision Rifle Series Iceland er íslenska útgáfan af alþjóðlegu PRS mótaseríunni. Við bjóðum upp á krefjandi og skemmtilegar keppnir þar sem skotmenn takast á við mismunandi aðstæður.",
+    "features": {
+      "competitions": {
+        "title": "PRS mót",
+        "description": "Keppt á vegalengdum frá 100-1000 metrum"
+      },
+      "community": {
+        "title": "Öflugt félag",
+        "description": "Yfir 150 virkir félagsmenn úti um allt land"
+      },
+      "recognition": {
+        "title": "Alþjóðleg viðurkenning",
+        "description": "Hluti af alþjóðlega PRS samfélaginu"
+      },
+      "coverage": {
+        "title": "Mót um allt land",
+        "description": "Keppt á völlunum beggja vegna landsins"
+      }
+    }
+  },
+  "matches": {
+    "title": "Næstu mót",
+    "subtitle": "Skráðu þig í komandi keppnir",
+    "ctaBox": {
+      "title": "Ertu tilbúinn í áskorun?",
+      "description": "Skráðu þig í næsta mót og taktu þátt í spennandi keppni"
+    },
+    "status": {
+      "open": "Opið",
+      "filling": "Að fyllast",
+      "full": "Fullbókað"
+    },
+    "registerButton": "Skrá í mót"
+  },
+  "standings": {
+    "title": "Stigastaða",
+    "subtitle": "2025 PRS Iceland Mótasería",
+    "tableHeaders": {
+      "rank": "Sæti",
+      "name": "Keppandi",
+      "division": "Flokkur",
+      "points": "Stig",
+      "percentage": "%"
+    },
+    "viewAll": "Sjá heildarstigastöðu →"
+  },
+  "stats": {
+    "activeMembers": {
+      "value": "150+",
+      "label": "Virkir Félagar",
+      "description": "Skráðir keppendur um allt land"
+    },
+    "matchesPerYear": {
+      "value": "24",
+      "label": "Mót á ári",
+      "description": "Fjölbreytt mót allan ársins hring"
+    },
+    "yearsActive": {
+      "value": "4",
+      "label": "Ár starfsemi",
+      "description": "Stofnað árið 2021"
+    },
+    "divisions": {
+      "value": "3",
+      "label": "Mótaflokkar",
+      "description": "Open, Production og Tactical"
+    }
+  },
+  "cta": {
+    "title": "Tilbúinn að keppa?",
+    "description": "Vertu hluti af fremsta PRS félagi Íslands",
+    "becomeMember": "Gerast félagsmaður",
+    "learnMore": "Fræðast meira"
+  },
+  "footer": {
+    "description": "Fremsta PRS félag Íslands",
+    "quickLinks": {
+      "title": "Flýtileiðir",
+      "matchRegistration": "Skráning í mót",
+      "standings": "Stigastaða",
+      "members": "Félagatal",
+      "about": "Um félagið"
+    },
+    "contact": {
+      "title": "Samband",
+      "email": "prs@prsiceland.is",
+      "address1": "Stekkjarseli 7",
+      "address2": "109 Reykjavík"
+    },
+    "social": {
+      "title": "Fylgdu okkur",
+      "facebook": "Facebook",
+      "instagram": "Instagram"
+    },
+    "copyright": "© 2025 PRS Iceland. Allur réttur áskilinn."
+  },
+  "registration": {
+    "modalTitle": "Skráning í",
+    "fields": {
+      "name": {
+        "label": "Nafn",
+        "placeholder": "Fullt nafn"
+      },
+      "email": {
+        "label": "Netfang",
+        "placeholder": "netfang@example.com"
+      },
+      "phonenumber": {
+        "label": "Sími",
+        "placeholder": "1234567"
+      },
+      "division": {
+        "label": "Flokkur",
+        "placeholder": "Veldu flokk",
+        "options": ["Open", "Production", "Tactical"]
+      },
+      "city": {
+        "label": "Bær/Sveitarfélag (valfrjálst)",
+        "placeholder": "t.d. Reykjavík"
+      }
+    },
+    "buttons": {
+      "cancel": "Hætta við",
+      "submit": "Staðfesta skráningu",
+      "submitting": "Skrái..."
+    },
+    "errors": {
+      "duplicate": "Þú ert þegar skráð(ur) í þetta mót",
+      "emailExists": "Netfang er þegar skráð fyrir annan keppanda",
+      "general": "Villa við skráningu. Vinsamlegast reyndu aftur."
+    }
+  },
+  "admin": {
+    "dashboard": {
+      "title": "Stjórnborð PRS Iceland",
+      "subtitle": "Stjórna mótum og úrslitum",
+      "tabs": {
+        "create": "Búa til",
+        "manage": "Stjórna",
+        "results": "Úrslit",
+        "edit": "Breyta",
+        "createMatch": "Búa til mót",
+        "manageMatches": "Stjórna mótum",
+        "recordResults": "Skrá úrslit",
+        "manageResults": "Stjórna úrslitum"
+      },
+      "notice": {
+        "title": "Athugið",
+        "text": "Þetta stjórnborð er enn í þróun. Authentication og öryggisatriði vantar áður en það fer í notkun. Öll gögn eru geymd í Supabase gagnagrunninum og uppfærast sjálfkrafa á vefsíðunni."
+      }
+    },
+    "matchForm": {
+      "title": "Búa til nýtt mót",
+      "fields": {
+        "name": {
+          "label": "Nafn móts",
+          "placeholder": "t.d. Vopnafjarðarmótið"
+        },
+        "date": {
+          "label": "Dagsetning"
+        },
+        "location": {
+          "label": "Staðsetning",
+          "placeholder": "t.d. Skotsvæði Vopnafjarðar"
+        },
+        "capacity": {
+          "label": "Hámarksfjöldi keppenda"
+        }
+      },
+      "buttons": {
+        "submit": "Búa til mót",
+        "submitting": "Vista..."
+      },
+      "messages": {
+        "success": "Mót búið til!",
+        "error": "Villa við að búa til mót"
+      }
+    },
+    "matchList": {
+      "title": "Öll mót",
+      "loading": "Sæki mót...",
+      "empty": "Engin mót skráð",
+      "status": {
+        "upcoming": "Framundan",
+        "ongoing": "Í gangi",
+        "completed": "Lokið"
+      },
+      "fields": {
+        "maxCapacity": "Hámark",
+        "location": "Staðsetning",
+        "capacity": "Hámarksfjöldi"
+      },
+      "buttons": {
+        "save": "Vista",
+        "cancel": "Hætta við",
+        "edit": "Breyta móti",
+        "delete": "Eyða móti"
+      },
+      "confirmDelete": "Ertu viss um að þú viljir eyða mótinu \"{{name}}\"? Þetta mun einnig eyða öllum skráningum.",
+      "messages": {
+        "updated": "Mót uppfært!",
+        "deleted": "Móti eytt!",
+        "loadError": "Villa við að sækja mót",
+        "updateError": "Villa við að uppfæra mót",
+        "deleteError": "Villa við að eyða móti"
+      }
+    },
+    "registrations": {
+      "title": "Stjórna skráningum",
+      "show": "Sýna",
+      "hide": "Fela",
+      "loading": "Sæki skráningar...",
+      "empty": "Engar skráningar fyrir þetta mót",
+      "registered": "Skráðir",
+      "status": {
+        "confirmed": "Staðfest",
+        "waitlist": "Biðlisti",
+        "cancelled": "Afboðað"
+      },
+      "buttons": {
+        "save": "Vista breytingar",
+        "cancel": "Hætta við",
+        "editStatus": "Breyta stöðu",
+        "delete": "Eyða skráningu"
+      },
+      "confirmDelete": "Ertu viss um að þú viljir eyða skráningu fyrir {{name}}?",
+      "messages": {
+        "statusUpdated": "Staða uppfærð!",
+        "deleted": "Skráningu eytt!",
+        "loadError": "Villa við að sækja skráningar",
+        "updateError": "Villa við að uppfæra stöðu",
+        "deleteError": "Villa við að eyða skráningu"
+      }
+    },
+    "results": {
+      "title": "Skrá úrslit móts",
+      "selectMatch": "Veldu mót",
+      "selectMatchOption": "-- Veldu mót --",
+      "maxScore": "Hámarksstig í móti",
+      "manualPoints": "Slá inn punkta handvirkt (annars reiknað eftir sæti)",
+      "competitors": "Keppendur",
+      "autoCalculated": "Prósenta reiknuð sjálfkrafa",
+      "fields": {
+        "name": "Nafn",
+        "division": "Flokkur",
+        "score": "Stig",
+        "percentage": "Prósenta",
+        "points": "Punktar",
+        "calculated": "(reiknað)",
+        "byPosition": "(eftir sæti)",
+        "required": "*"
+      },
+      "explanation": {
+        "title": "Útskýringar:",
+        "score": "Stig: Heildarstig keppanda í mótinu (handvirt)",
+        "percentage": "Prósenta: Reiknað sjálfkrafa = (Stig / Hámarksstig) × 100",
+        "pointsManual": "Punktar: Slegið inn handvirkt",
+        "pointsAuto": "Punktar: Reiknað eftir sæti (1. sæti = 100p, 2. = 95p, o.s.frv.)"
+      },
+      "buttons": {
+        "save": "Vista úrslit",
+        "saving": "Vista úrslit..."
+      },
+      "messages": {
+        "success": "Úrslit vistuð!",
+        "error": "Villa við að vista úrslit"
+      }
+    }
+  },
+  "common": {
+    "loading": "Hleður...",
+    "error": "Villa",
+    "success": "Aðgerð tókst",
+    "save": "Vista",
+    "cancel": "Hætta við",
+    "delete": "Eyða",
+    "edit": "Breyta",
+    "close": "Loka",
+    "confirm": "Staðfesta",
+    "search": "Leita",
+    "filter": "Sía",
+    "all": "Allt",
+    "none": "Ekkert",
+    "yes": "Já",
+    "no": "Nei",
+    "auto": "Auto"
+  },
+  "seo": {
+    "defaultTitle": "PRS Iceland - Precision Rifle Series",
+    "description": "Fremsta precision rifling félag Íslands."
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import './i18n'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
- Install and configure react-i18next
- Create translation files for Icelandic (default) and English
- Add language toggle component to header
- Update navigation and hero components to use translations
- Default language is Icelandic unless user explicitly selects English
- Language preference persists in localStorage

The foundation is set for full site translation. Remaining components can be gradually updated to use the translation system.

🤖 Generated with [Claude Code](https://claude.ai/code)