### PR TITLE
fix: translate match registration list text

### DIFF
--- a/src/components/MatchRegistrations.jsx
+++ b/src/components/MatchRegistrations.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { Users, ChevronDown, ChevronUp } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { registrationApi } from '../lib/supabase';
 
 function MatchRegistrations({ match }) {
+  const { t } = useTranslation();
   const [registrations, setRegistrations] = useState([]);
   const [loading, setLoading] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -32,16 +34,16 @@ function MatchRegistrations({ match }) {
         className="flex items-center gap-2 text-sm text-zinc-400 hover:text-zinc-300 transition-colors"
       >
         <Users className="h-4 w-4" />
-        <span>Sjá skráða keppendur ({match.registered || 0})</span>
+        <span>{t('matches.viewRegistrations')} ({match.registered || 0})</span>
         {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
       </button>
 
       {expanded && (
         <div className="mt-4">
           {loading ? (
-            <p className="text-sm text-zinc-500">Sæki lista...</p>
+            <p className="text-sm text-zinc-500">{t('matches.loadingRegistrations')}</p>
           ) : registrations.length === 0 ? (
-            <p className="text-sm text-zinc-500">Enginn skráður ennþá</p>
+            <p className="text-sm text-zinc-500">{t('matches.noRegistrations')}</p>
           ) : (
             <div className="space-y-2">
               {registrations.map((reg, index) => (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -55,7 +55,10 @@
     "loading": "Loading match information...",
     "noMatches": "No matches scheduled",
     "competitors": "competitors",
-    "matchFull": "Match full"
+    "matchFull": "Match full",
+    "viewRegistrations": "View registered competitors",
+    "loadingRegistrations": "Loading list...",
+    "noRegistrations": "No one registered yet"
   },
   "standings": {
     "title": "Standings",

--- a/src/i18n/locales/is.json
+++ b/src/i18n/locales/is.json
@@ -55,7 +55,10 @@
     "loading": "Sæki upplýsingar um mót...",
     "noMatches": "Engin mót á dagskrá",
     "competitors": "keppendur",
-    "matchFull": "Mót fullt"
+    "matchFull": "Mót fullt",
+    "viewRegistrations": "Sjá skráða keppendur",
+    "loadingRegistrations": "Sæki lista...",
+    "noRegistrations": "Enginn skráður ennþá"
   },
   "standings": {
     "title": "Stigastaða",


### PR DESCRIPTION
The match registration expandable list had hardcoded Icelandic text:
- 'Sjá skráða keppendur' (View registered competitors)
- 'Sæki lista...' (Loading list)
- 'Enginn skráður ennþá' (No one registered yet)

All text now properly uses the i18n translation system.